### PR TITLE
DOM Button Refinements

### DIFF
--- a/BondageClub/CSS/Styles.css
+++ b/BondageClub/CSS/Styles.css
@@ -136,23 +136,20 @@ TextArea {
 .button {
   border: 2px solid black;
   color: black;
-  background: none;
   background-color: white;
   background-size: cover;
   background-origin: content-box;
   background-repeat: no-repeat;
   text-align: center;
-  text-decoration: none;
-  resize: "none";
   padding: 0.15em;
 }
 
-.button:hover {
+.button:hover, .button:focus {
 	background-color: cyan;
 	color: white;
 }
 
-button > .tooltip {
+.button > .tooltip {
 	box-shadow: 0 0 10px 0 rgba(0, 0, 0, 0.5);
 	position: absolute;
 	background-color: #fffb8f;
@@ -164,9 +161,38 @@ button > .tooltip {
 	border: 2px solid;
 	opacity: 0;
   	transition: opacity 0.5s;
+	white-space: nowrap;
 }
 
-button:hover > .tooltip {
+.button > .tooltip.left, .button > .tooltip.right {
+	top: 50%;
+	transform: translateY(-50%);
+	margin: 0 0.25em;
+}
+
+.button > .tooltip.top, .button > .tooltip.bottom {
+	left: 50%;
+	transform: translateX(-50%);
+	margin: 0.25em 0;
+}
+
+.button > .tooltip.left {
+	right: 100%;
+}
+
+.button > .tooltip.right {
+	left: 100%;
+}
+
+.button > .tooltip.top {
+	bottom: 100%;
+}
+
+.button > .tooltip.bottom {
+	top: 100%;
+}
+
+.button:hover > .tooltip, .button:focus > .tooltip {
 	visibility: visible;
 	opacity: 1;
 }

--- a/BondageClub/Screens/Character/InformationSheet/InformationSheet.js
+++ b/BondageClub/Screens/Character/InformationSheet/InformationSheet.js
@@ -25,29 +25,27 @@ function InformationSheetGetLove(Love) {
 /**
  * This function is executed, when the information screen is loaded. Defines the buttons on the right hand side
  * and adds functions for the event handlers. These can either be existing functions or on the fly defined inline functions
- * @returns {vois} - Nothing
+ * @returns {void} - Nothing
  */
 function InformationSheetLoad() {
 	ElementCreateButton("btnExit", "", "Icons/Exit.png", "Exit", "left", InformationSheetExit);
-	ElementCreateButton("btnTitle", "", "Icons/Title.png", "Title", "left", function () {
-		CommonSetScreen("Character", "Title");
+	ElementCreateButton("btnTitle", "", "Icons/Title.png", "Title", "left", InformationSheetCurrySetScreen("Title"));
+	ElementCreateButton("btnPref", "", "Icons/Preference.png", "Preferences", "left", InformationSheetCurrySetScreen("Preference"));
+	ElementCreateButton("btnFriends", "", "Icons/FriendList.png", "Friends", "left", InformationSheetCurrySetScreen("FriendList"));
+	ElementCreateButton("btnIntro", "", "Icons/Introduction.png", "Online Profile", "left", InformationSheetCurrySetScreen("OnlineProfile"));
+	ElementCreateButton("btnNext", "", "Icons/Next.png", "Next Page", "left", () => (InformationSheetSecondScreen = !InformationSheetSecondScreen));
+}
+
+/**
+ * Creates a curried callback for setting the information sheet screen
+ * @param {string} ScreenName - The name of the screen that the curried function should switch to
+ * @returns {function(): void} - A curried function that clears information sheet buttons and sets the relevant screen
+ */
+function InformationSheetCurrySetScreen(ScreenName) {
+	return () => {
 		InformationSheetButtonsRemove();
-	});
-	ElementCreateButton("btnPref", "", "Icons/Preference.png", "Preferences", "left", function () {
-		InformationSheetButtonsRemove();
-		CommonSetScreen("Character", "Preference");
-	});
-	ElementCreateButton("btnFriends", "", "Icons/FriendList.png", "Friends", "left", function () {
-		InformationSheetButtonsRemove();
-		CommonSetScreen("Character", "FriendList");
-	});
-	ElementCreateButton("btnIntro", "", "Icons/Introduction.png", "Online Profile", "left", function () {
-		InformationSheetButtonsRemove();
-		CommonSetScreen("Character", "OnlineProfile");
-	});
-	ElementCreateButton("btnNext", "", "Icons/Next.png", "Next Page", "left", function () {
-		InformationSheetSecondScreen = !InformationSheetSecondScreen;
-	});
+		CommonSetScreen("Character", ScreenName);
+	};
 }
 
 /**

--- a/BondageClub/Scripts/Element.js
+++ b/BondageClub/Scripts/Element.js
@@ -39,48 +39,34 @@ function ElementContent(ID, Content) {
  * @param {string} hoverText - Text for a tool tip that is shown, when the mouse hovers over the button
  * @param {string} hoverPos - Hint for the positioning of the tool tip. 
  * Valid values are "bottom", "top", "right" or "left". If no value is given, "left" is used
- * @param {function} func - A function for the 'click' event handler. Code withhin this function is executed, 
- * as sson as the user clicks on the button
+ * @param {function} func - A function for the 'click' event handler. Code within this function is executed,
+ * as soon as the user clicks on the button (or hits enter on the button)
  * @returns {void} - Nothing
  */
 function ElementCreateButton(ID, label, image, hoverText, hoverPos, func) {
-
-	if (document.getElementById(ID) == null) {
-		var button = document.createElement("button");
+	if (!document.getElementById(ID)) {
+		const button = document.createElement("button");
 		button.className = "button";
 		button.setAttribute("type", "button");
 		button.setAttribute("ID", ID);
 		button.setAttribute("Name", ID);
-		if (image != "") button.style.backgroundImage = "url(" + DrawGetImage(image).src + ")";
-		if (label != "") button.value = label;
-		if (toolTip != "") {
-			if (hoverPos === "") hoverPos = "left";
+		if (image) button.style.backgroundImage = "url(" + DrawGetImage(image).src + ")";
+		if (label) {
+			const span = document.createElement("span");
+			span.classList.add("buttonContent")
+			span.innerText = label;
+			button.appendChild(span);
+		} else if (hoverText) {
+			button.setAttribute("aria-label", hoverText);
+		}
+		if (hoverText) {
+			if (!["left", "right", "top", "bottom"].includes(hoverPos)) hoverPos = "left";
 			var toolTip = document.createElement(ID + "_tooltip");
-			toolTip.className = "tooltip";
+			toolTip.classList.add("tooltip", hoverPos);
 			toolTip.innerText = hoverText;
-			switch (hoverPos) {
-				case "right":
-					toolTip.style.top = "-5px";
-					toolTip.style.left = "105%";
-					break;
-				case "top":
-					toolTip.style.bottom = "100%";
-					toolTip.style.left = "50%";
-					toolTip.style.marginLeft = "-60px";
-					break;
-				case "bottom":
-					toolTip.style.top = "100%";
-					toolTip.style.left = "50%";
-					toolTip.style.marginLeft = "-60px";
-					break;
-				default:
-					// Left is the default
-					toolTip.style.top = "5px";
-					toolTip.style.right = "80%";
-			} // switch
 			button.appendChild(toolTip);
-		} // if (toolTip)
-		if (func != null) button.addEventListener("click", func);
+		}
+		if (typeof func === "function") button.addEventListener("click", func);
 		document.body.appendChild(button);
 	}
 }


### PR DESCRIPTION
## Summary of changes

* Removes a few redundant CSS rules
* Moves handling of button tooltip positioning into CSS via classes to try to pull as much of the styling responsibility into CSS as possible. Also makes some slight changes to the tooltips so they are positioned a little more like the existing tooltips.
* Refactors the common set screen callback in the information sheet into a curried function call
* Some minor typo fixes in JSDoc
* Adds focus styles and `aria-label` attributes to the buttons where appropriate - should make them generally more accessible (I'd be surprised if anyone was actually playing the game with a screen reader, but it's always a plus to keep things as accessible as possible, and this makes the preference screen navigable entirely with a keyboard via the tab and enter keys).
* Changes the `ElementCreateButton` function so that the label gets rendered (eventually it will probably be worth refactoring this further to support both text & icons so that we can use this on the preference home screen, but this should be fine for now)